### PR TITLE
add **kwargs to pass unconventional args to a personalized file_parser()

### DIFF
--- a/Make_TFRecord_Class.py
+++ b/Make_TFRecord_Class.py
@@ -44,7 +44,7 @@ def return_data_dict(niftii_path):
 
 def write_tf_record(niftii_path, out_path=None, rewrite=False, thread_count=int(cpu_count() * .5), max_records=np.inf,
                     is_3D=True, extension=np.inf, image_processors=None, special_actions=False, verbose=False,
-                    file_parser=None, debug=False, recordwriter=None):
+                    file_parser=None, debug=False, recordwriter=None, **kwargs):
     """
     :param niftii_path: path to where Overall_Data and mask files are located
     :param out_path: path that we will write records to
@@ -92,7 +92,7 @@ def write_tf_record(niftii_path, out_path=None, rewrite=False, thread_count=int(
     if file_parser is None:
         data_dict = return_data_dict(niftii_path=niftii_path)
     else:
-        data_dict = file_parser(**locals())
+        data_dict = file_parser(**locals(), **kwargs)
     counter = 0
     for iteration in data_dict.keys():
         item = copy.deepcopy(data_dict[iteration])


### PR DESCRIPTION
add **kwargs to pass unconventional args to a personalized file_parser()

for example:

write_tf_record(niftii_path=in_path, out_path=out_path, is_3D=False, image_processors=image_processors,
special_actions=True, thread_count=int(cpu_count() * .80), debug=debug, rewrite=True,
file_parser=return_data_dict_all_modality, corresp_dict=corresp_dict)